### PR TITLE
Replace manual title tag with jekyll-seo-tag

### DIFF
--- a/_layouts/common.html
+++ b/_layouts/common.html
@@ -2,17 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>
-            {% if page.url != '/' %}
-            {% if page.layout == 'bin' %}
-            {{ page.title | downcase }}
-            {% else %}
-            {{ page.title }}
-            {% endif %}
-            |
-            {% endif %}
-            {{ site.title }}
-        </title>
+        {% seo %}
         <link rel="shortcut icon" href="/favicon.ico" />
         <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
         <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">


### PR DESCRIPTION
Remove the hand-written <title> block from common.html and replace it with the {% seo %} tag. This generates title, canonical URL, meta description, Open Graph tags, Twitter Card tags, and JSON-LD structured data from _config.yml and page front matter.