### PR TITLE
Fix twitter:creator, og/twitter title format, and 404 rendering

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,4 +6,4 @@ permalink: /404.html
 sitemap: false
 ---
 
-The page you requested could not be found. Return to the [homepage](/) or search for a specific binary.
+<p>The page you requested could not be found. Return to the <a href="/">homepage</a> or search for a specific binary.</p>

--- a/_config.yml
+++ b/_config.yml
@@ -12,11 +12,10 @@ include:
   - llms.txt
   - llms-full.txt
 
-exclude: ['/scripts', '/Gemfile', '/Makefile', '/README.md', '/CONTRIBUTING.md']
-
 author:
   name: Joshua Rogers
   url: "https://joshua.hu/"
+  twitter: megamansec
 
 twitter:
   username: megamansec

--- a/_layouts/common.html
+++ b/_layouts/common.html
@@ -3,6 +3,8 @@
     <head>
         <meta charset="utf-8">
         {% seo %}
+        {% if page.title and page.title != site.title %}<meta property="og:title" content="{{ page.title }} | {{ site.title }}" />
+        <meta name="twitter:title" content="{{ page.title }} | {{ site.title }}" />{% endif %}
         <link rel="shortcut icon" href="/favicon.ico" />
         <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
         <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">


### PR DESCRIPTION
- Add author.twitter to _config.yml so twitter:creator renders as @megamansec instead of @Joshua Rogers
- Override og:title and twitter:title in common.html to include the site title (e.g. "awk | GTFOArgs: ..." instead of just "awk")
- Fix 404 page rendering raw markdown by using HTML for the link
- Remove duplicate exclude key in _config.yml from merge